### PR TITLE
fix: deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.19.8)
 
 project(shoom)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.19.8)
 
 project(test)
 


### PR DESCRIPTION
Fixed the < 2.8 deprecation warning (running cmake 3+) by raising the min version to an appropriate up-to-date level